### PR TITLE
Remove redundant  curly brace in the log string

### DIFF
--- a/scripts/registerDerivativeCommercialSpg.ts
+++ b/scripts/registerDerivativeCommercialSpg.ts
@@ -62,7 +62,7 @@ const main = async function () {
         },
         txOptions: { waitForTransaction: true },
     })
-    console.log(`Derivative IPA created and linked at transaction hash ${txHash}, IPA ID: ${childIpId}}`)
+    console.log(`Derivative IPA created and linked at transaction hash ${txHash}, IPA ID: ${childIpId}`)
 
     // 4. Pay Royalty
     // NOTE: You have to approve the RoyaltyModule to spend 2 SUSD on your behalf first. See README for instructions.


### PR DESCRIPTION
## Description

In the template string, there is an extra curly brace after the childIpId variable, which causes incorrect text to be output to the console (an additional } at the end).

