### PR TITLE
chore: fix incorrect URL and remove redundant type casting

### DIFF
--- a/scripts/disputeIp.ts
+++ b/scripts/disputeIp.ts
@@ -26,9 +26,9 @@ const main = async function () {
 
     // 2. Raise a Dispute
     //
-    // Docs: https://docs.story.foundation/docs/sdk-dispute#raisedispute
+    // Docs: https://docs.story.foundation/docs/sdk-dispute#raiseDispute
     const disputeResponse = await client.dispute.raiseDispute({
-        targetIpId: ipResponse.ipId as Address,
+        targetIpId: ipResponse.ipId,
         // NOTE: you must use your own CID here, because every time it is used,
         // the protocol does not allow you to use it again
         cid: 'QmbWqxBEKC3P8tqsKc98xmWNzrzDtRLMiMPL8wBuTGsMnR',


### PR DESCRIPTION
## **Description**  
- Fixed an incorrect URL in a comment: `raiseDispute` should be in camelCase to match the documentation.  
- Removed redundant type casting (`as Address`) since `ipResponse.ipId` is already a string.  

## **Test Plan**  
- Verified that the updated URL correctly links to the intended section.  
- Ensured that removing the type cast does not affect functionality.  

## **Notes**  
No functional changes, just minor cleanup for clarity and correctness.